### PR TITLE
Added .alcache to gitignore for skipping temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.flf
 /.vscode/rad.json
 /.vscode/launch.json
+/.vscode/.alcache/


### PR DESCRIPTION
When you work on existing extensions .alchache folder with some temp files is created. Please add it to git ignore, so that it is not pushed accidentally.